### PR TITLE
TWBR register should not be hardcoded

### DIFF
--- a/Adafruit_MCP4725.cpp
+++ b/Adafruit_MCP4725.cpp
@@ -65,7 +65,7 @@ void Adafruit_MCP4725::begin(uint8_t addr) {
 void Adafruit_MCP4725::setVoltage( uint16_t output, bool writeEEPROM )
 {
   uint8_t twbrback = TWBR;
-  TWBR = 12; // 400 khz
+  TWBR = ((F_CPU / 400000L) - 16) / 2; // Set I2C frequency to 400kHz
   Wire.beginTransmission(_i2caddr);
   if (writeEEPROM)
   {


### PR DESCRIPTION
The TWBR register value should not be hardcoded, as it will not work as intended on devices running at another frequency than 16MHz.

For instance the I2C frequency of a microcontroller running at 8MHz would only be 200kHz:

```
(8 * 10^6) / ((12 * 2) + 16) = 200000
```

The line is actually just taken from the Arduino source code: https://github.com/arduino/Arduino/blob/master/libraries/Wire/utility/twi.c#L82.
