### PR TITLE
Added support for MCP4725’s power-down mode

### DIFF
--- a/Adafruit_MCP4725.h
+++ b/Adafruit_MCP4725.h
@@ -1,3 +1,6 @@
+#ifndef adafruit_mcp4725_h
+#define adafruit_mcp4725_h
+
 /**************************************************************************/
 /*! 
     @file     Adafruit_MCP4725.h
@@ -25,15 +28,22 @@
 
 #include <Wire.h>
 
-#define MCP4726_CMD_WRITEDAC            (0x40)  // Writes data to the DAC
-#define MCP4726_CMD_WRITEDACEEPROM      (0x60)  // Writes data to the DAC and the EEPROM (persisting the assigned value after reset)
+#define MCP4726_CMD_WRITEDAC                0x40  // Writes data to the DAC
+#define MCP4726_CMD_WRITEDACEEPROM          0x60  // Writes data to the DAC and the EEPROM (persisting the assigned value after reset)
+#define MCP4725_OUTPUT_LOAD_RESISTANCE_1K   0
+#define MCP4725_OUTPUT_LOAD_RESISTANCE_100K 1
+#define MCP4725_OUTPUT_LOAD_RESISTANCE_500K 2
 
 class Adafruit_MCP4725{
  public:
   Adafruit_MCP4725();
   void begin(uint8_t a);  
-  void setVoltage( uint16_t output, bool writeEEPROM );
+  void setVoltage(uint16_t output, bool writeEEPROM);
+  void powerDown(uint8_t loadResistance, bool writeEEPROM);
 
  private:
   uint8_t _i2caddr;
+  void writeI2cPacket(uint8_t controlBits, uint16_t data);
 };
+
+#endif

--- a/examples/powerdown/powerdown.ino
+++ b/examples/powerdown/powerdown.ino
@@ -1,0 +1,59 @@
+/**************************************************************************/
+/*!
+    @file     powerdown.pde
+    @author   Alex Mitchell (MitchellSoft Technology Ltd.)
+    @license  BSD (see license.txt)
+
+    This example shows how to put the MCP4725 into power-down mode.
+    During power-down mode, the device draws about 60 nA, compared
+    against 200 µA (typical) when running in normal mode.
+    
+    When in power-down mode, the output pin is connected to ground via
+    a configurable pull-down resistance of either 1K, 100K, or 500K Ohms.
+    
+    To bring the device out of power-down mode, simply call setVoltage
+    (it will also wake up if an I2C General Call Wake-Up Command is sent
+    on the I2C bus).
+
+    This is an example sketch for the Adafruit MCP4725 breakout board
+    ----> http://www.adafruit.com/products/935
+
+    Adafruit invests time and resources providing this open source code,
+    please support Adafruit and open-source hardware by purchasing
+    products from Adafruit!
+*/
+/**************************************************************************/
+#include <Wire.h>
+#include <Adafruit_MCP4725.h>
+
+Adafruit_MCP4725 dac;
+
+void setup(void) {
+  Serial.begin(9600);
+  Serial.println("Hello!");
+
+  // For Adafruit MCP4725A1 the address is 0x62 (default) or 0x63 (ADDR pin tied to VCC)
+  // For MCP4725A0 the address is 0x60 or 0x61
+  // For MCP4725A2 the address is 0x64 or 0x65
+  dac.begin(0x62);
+    
+  Serial.println("Example sketch demonstrating the MCP4725 power-down mode");
+}
+
+void loop(void) {
+  Serial.println("Putting MCP4725 to sleep.  Output pin connected to ground via 1K Ohm resistance.");
+  dac.powerDown(MCP4725_OUTPUT_LOAD_RESISTANCE_1K, false);
+  delay(5000);
+  
+  Serial.println("Switching sleep mode.  Output pin now connected ot ground via 100K Ohm resistance.");
+  dac.powerDown(MCP4725_OUTPUT_LOAD_RESISTANCE_100K, false);
+  delay(5000);
+  
+  Serial.println("Waking device up by setting an output voltage.");
+  dac.setVoltage(1000, false);
+  delay(5000);
+  
+  Serial.println("Putting MCP4725 to sleep again.  Output pin connected to ground via 500K Ohm resistance.");
+  dac.powerDown(MCP4725_OUTPUT_LOAD_RESISTANCE_500K, false);
+  delay(5000);
+}


### PR DESCRIPTION
* Added the powerDown method to put the MCP4725 into power-down mode.
I defaulted the pull-down resistance to 500k Ohm in the case where an invalid value
for loadResistance is passed to the method.  It seemed safer to default to a high
impedance rather than a low.
* Created an example sketch to show how the powerDown method is used
* Added #include guard to Adafruit_MCP4725.h to avoid problems of double inclusion, which I experienced when trying to use the library in Sloeber

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
