### PR TITLE
Add include guards around header file

### DIFF
--- a/Adafruit_MCP4725.h
+++ b/Adafruit_MCP4725.h
@@ -17,6 +17,9 @@
 */
 /**************************************************************************/
 
+#ifndef _ADAFRUIT_MCP4725_H_
+#define _ADAFRUIT_MCP4725_H_
+
 #if ARDUINO >= 100
  #include "Arduino.h"
 #else
@@ -37,3 +40,5 @@ class Adafruit_MCP4725{
  private:
   uint8_t _i2caddr;
 };
+
+#endif


### PR DESCRIPTION
Prevents compile errors when the header file happens to be included twice in a source file. This can happen with automated builds and other "odd" build systems.